### PR TITLE
Homepage cover fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@ texts: passive
 
 <hr>
 
-    <!-- Row of columns with covers below carousel hero unit -->
+    <!-- Row of 4 columns with 4 covers below carousel hero unit -->
 	<div class="row covers">
 	
-	<!-- First cover -->
+		<!-- First cover -->
     	<div class="span3">
         	<h4>This Fatal Looking Glass</h4>
 			<a href="/texts/this-fatal.html"><img class="img-square cover" src="/img/covers/mcs-200px.png"></a>
@@ -52,6 +52,12 @@ texts: passive
 			<a href="/texts/if-reality-doesnt-work-out.html"><img class="img-square cover" src="/img/covers/zaher-200px.png"></a>
 			<p>Maged Zaher. Summer 2014.</p>
         </div>
+        
+    </div> <!-- /.row -->
+    
+    <!-- Row of 4 columns with 4 covers below row of covers -->
+    <div class="row covers">
+    
     	<!-- Fifth cover -->	
     	<div class="span3">
         	<h4>W—/M—</h4>
@@ -76,6 +82,7 @@ texts: passive
 			<a href="/texts/a-cruel-nirvana"><img class="img-square cover" src="/img/covers/rothenberg-200px.png"></a>
 			<p>Jerome Rothenberg. 2012.</p>
         </div>
+        
 	</div><!-- /.row -->
     
     <!-- Row for More button below covers -->  


### PR DESCRIPTION
Fixing display of covers on homepage by grouping covers in a div class = row that contains four columns, each cover to a column. The result is two rows of 4 columns. 